### PR TITLE
Feature/advanced field naming strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+# Fabulous fork
+
+This fork is a copy of the original Gson repository with the following changes:
+
+- `FieldNamingStrategy` interface has a new default method `translateNameWithAlternatives()` that can be overridden so
+  that we can create a universal deserializer which supports camelCase and `snake_case` naming conventions when
+  deserializing
+- `ReflectiveTypeAdapterFactory` uses `fieldNamingPolicy.translateNameWithAlternatives()` to consider alternative json
+  field names when deserializing
+- updated source version to 1.8
+- added dependency to `com.google.j2objc:j2objc-annotations:1.3` and used @Weak and @WeakOuter annotations to avoid
+  memory leaks in j2objc
+
+## Building gson and using it in Fabulous Core project
+
+1. Gson is built using maven. Run the following command to build the project:
+   ```shell
+   mvn source:jar package
+   ```
+2. this will create a `gson-2.8.8.jar` and `gson-2.8.9-sources.jar` files in the `target` directory
+3. copy the above files to `fabulous-core/libs/` directory in the Fabulous Core project
+
 # Gson
 
 Gson is a Java library that can be used to convert Java Objects into their JSON representation. It can also be used to convert a JSON string to an equivalent Java object.

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -27,6 +27,12 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.j2objc</groupId>
+      <artifactId>j2objc-annotations</artifactId>
+      <version>1.3</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
@@ -45,8 +45,8 @@ public interface FieldNamingStrategy {
      * JSON field name when deserialising the object. When serialising, the frist value will be used.
      *
      * @param f the field object that we are translating
-     * @return list of the translated field names that will be checked during deserialisation. For serialization only
-     * the first oe will be used.
+     * @return list of the translated field names that will be checked during deserialisation.
+     * For serialization only the first one will be used.
      */
     default public List<String> translateNameWithAlternatives(Field f) {
         return Collections.singletonList(translateName(f));

--- a/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
@@ -40,6 +40,14 @@ public interface FieldNamingStrategy {
      */
     public String translateName(Field f);
 
+    /**
+     * Translates the field name into its alternative JSON field name representations, Gson will use the first existing
+     * JSON field name when deserialising the object. When serialising, the frist value will be used.
+     *
+     * @param f the field object that we are translating
+     * @return list of the translated field names that will be checked during deserialisation. For serialization only
+     * the first oe will be used.
+     */
     default public List<String> translateNameWithAlternatives(Field f) {
         return Collections.singletonList(translateName(f));
     }

--- a/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
@@ -17,6 +17,8 @@
 package com.google.gson;
 
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Collections;
 
 /**
  * A mechanism for providing custom field naming in Gson. This allows the client code to translate
@@ -29,12 +31,16 @@ import java.lang.reflect.Field;
  */
 public interface FieldNamingStrategy {
 
-  /**
-   * Translates the field name into its JSON field name representation.
-   *
-   * @param f the field object that we are translating
-   * @return the translated field name.
-   * @since 1.3
-   */
-  public String translateName(Field f);
+    /**
+     * Translates the field name into its JSON field name representation.
+     *
+     * @param f the field object that we are translating
+     * @return the translated field name.
+     * @since 1.3
+     */
+    public String translateName(Field f);
+
+    default public List<String> translateNameWithAlternatives(Field f) {
+        return Collections.singletonList(translateName(f));
+    }
 }

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -20,7 +20,7 @@ import com.google.gson.internal.LinkedTreeMap;
 
 import java.util.Map;
 import java.util.Set;
-
+import com.google.j2objc.annotations.Weak;
 /**
  * A class representing an object type in Json. An object consists of name-value pairs where names
  * are strings, and values are any other type of {@link JsonElement}. This allows for a creating a
@@ -30,6 +30,8 @@ import java.util.Set;
  * @author Joel Leitch
  */
 public final class JsonObject extends JsonElement {
+
+  @Weak
   private final LinkedTreeMap<String, JsonElement> members =
       new LinkedTreeMap<String, JsonElement>();
 

--- a/gson/src/main/java/com/google/gson/internal/LinkedHashTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedHashTreeMap.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import com.google.j2objc.annotations.WeakOuter;
 
 /**
  * A map of comparable keys to values. Unlike {@code TreeMap}, this class uses
@@ -455,6 +456,7 @@ public final class LinkedHashTreeMap<K, V> extends AbstractMap<K, V> implements 
   }
 
   private EntrySet entrySet;
+
   private KeySet keySet;
 
   @Override public Set<Entry<K, V>> entrySet() {
@@ -794,6 +796,7 @@ public final class LinkedHashTreeMap<K, V> extends AbstractMap<K, V> implements 
     }
   }
 
+  @WeakOuter
   final class EntrySet extends AbstractSet<Entry<K, V>> {
     @Override public int size() {
       return size;
@@ -829,6 +832,7 @@ public final class LinkedHashTreeMap<K, V> extends AbstractMap<K, V> implements 
     }
   }
 
+  @WeakOuter
   final class KeySet extends AbstractSet<K> {
     @Override public int size() {
       return size;

--- a/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import com.google.j2objc.annotations.WeakOuter;
 
 /**
  * A map of comparable keys to values. Unlike {@code TreeMap}, this class uses
@@ -427,6 +428,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   }
 
   private EntrySet entrySet;
+
   private KeySet keySet;
 
   @Override public Set<Entry<K, V>> entrySet() {
@@ -439,6 +441,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     return result != null ? result : (keySet = new KeySet());
   }
 
+  @WeakOuter
   static final class Node<K, V> implements Entry<K, V> {
     Node<K, V> parent;
     Node<K, V> left;
@@ -560,6 +563,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     }
   }
 
+  @WeakOuter
   class EntrySet extends AbstractSet<Entry<K, V>> {
     @Override public int size() {
       return size;
@@ -595,6 +599,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     }
   }
 
+  @WeakOuter
   final class KeySet extends AbstractSet<K> {
     @Override public int size() {
       return size;

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -73,8 +73,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   private List<String> getFieldNames(Field f) {
     SerializedName annotation = f.getAnnotation(SerializedName.class);
     if (annotation == null) {
-      String name = fieldNamingPolicy.translateName(f);
-      return Collections.singletonList(name);
+      return fieldNamingPolicy.translateNameWithAlternatives(f);
     }
 
     String serializedName = annotation.value();

--- a/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
@@ -32,6 +32,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import com.google.j2objc.annotations.WeakOuter;
 
 /**
  * Adapts a Gson 1.x tree-style adapter as a streaming TypeAdapter. Since the
@@ -150,6 +151,7 @@ public final class TreeTypeAdapter<T> extends TypeAdapter<T> {
     }
   }
 
+  @WeakOuter
   private final class GsonContextImpl implements JsonSerializationContext, JsonDeserializationContext {
     @Override public JsonElement serialize(Object src) {
       return gson.toJsonTree(src);

--- a/gson/src/main/java/module-info.java
+++ b/gson/src/main/java/module-info.java
@@ -8,9 +8,11 @@ module com.google.gson {
 	exports com.google.gson.reflect;
 	exports com.google.gson.stream;
 
-	// Optional dependency on java.sql
-	requires static java.sql;
 
+	// Optional dependency on java.sql
+	requires static j2objc.annotations;
+	requires static java.sql;
+	// requires static java.annotation;
 	// Optional dependency on jdk.unsupported for JDK's sun.misc.Unsafe
 	requires static jdk.unsupported;
 }

--- a/gson/src/main/java/module-info.java
+++ b/gson/src/main/java/module-info.java
@@ -12,7 +12,6 @@ module com.google.gson {
 	// Optional dependency on java.sql
 	requires static j2objc.annotations;
 	requires static java.sql;
-	// requires static java.annotation;
 	// Optional dependency on jdk.unsupported for JDK's sun.misc.Unsafe
 	requires static jdk.unsupported;
 }

--- a/gson/src/test/java/com/google/gson/internal/LinkedHashTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedHashTreeMapTest.java
@@ -302,7 +302,7 @@ public final class LinkedHashTreeMapTest extends TestCase {
   }
 
   @SafeVarargs
-  private <T> void assertIterationOrder(Iterable<T> actual, T... expected) {
+  private final <T> void assertIterationOrder(Iterable<T> actual, T... expected) {
     ArrayList<T> actualList = new ArrayList<T>();
     for (T t : actual) {
       actualList.add(t);

--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
@@ -161,7 +161,7 @@ public final class LinkedTreeMapTest extends TestCase {
   }
 
   @SafeVarargs
-  private <T> void assertIterationOrder(Iterable<T> actual, T... expected) {
+  private final <T> void assertIterationOrder(Iterable<T> actual, T... expected) {
     ArrayList<T> actualList = new ArrayList<T>();
     for (T t : actual) {
       actualList.add(t);

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
+    <java.version>1.6</java.version>
   </properties>
 
   <scm>
@@ -91,8 +91,8 @@
             <jdkToolchain>
               <version>[1.5,9)</version>
             </jdkToolchain>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.6</java.version>
+    <java.version>1.8</java.version>
   </properties>
 
   <scm>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -126,8 +126,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
forking gson to:
- allow for universal deserializer which accepts both `snake_case` and `camelCase` of the same field
- allow for using gson in core for j2objc translation, as we needed to fix some retain cycles before it could be used on iOS